### PR TITLE
Holes

### DIFF
--- a/Poly/Main.hs
+++ b/Poly/Main.hs
@@ -47,7 +47,6 @@ handleCommand s = handleInput s
 handleInput :: String -> Interactive ()
 handleInput s = do
   t <- parseExpr "<repl>" s ?? SyntaxErr
-  liftIO $ print t
   (Forall _ ty) <- typecheckTerm t
   env <- get
   term <- compile (fromEnvironment env) t ?? CompileErr

--- a/Poly/Main.hs
+++ b/Poly/Main.hs
@@ -47,6 +47,7 @@ handleCommand s = handleInput s
 handleInput :: String -> Interactive ()
 handleInput s = do
   t <- parseExpr "<repl>" s ?? SyntaxErr
+  liftIO $ print t
   (Forall _ ty) <- typecheckTerm t
   env <- get
   term <- compile (fromEnvironment env) t ?? CompileErr

--- a/Poly/hole-implementation.org
+++ b/Poly/hole-implementation.org
@@ -1,0 +1,7 @@
+* First try
+The naive implementation of just instantiating a fresh name for each hole doesn't work.
+   - Because, look at the term /let f = ? in f 1/. The hole should have a type of /int -> c/ for all /c/.
+   - The inference rule for /let/ will generalise the type it's inferred for /f/, namely /a/ (a fresh variable for the hole)
+   - The generalisation of /a/ is /∀ a . a/.
+   - Then, when the type of /f/ is inferred in the application /f 1/, it's instantiated, giving a new fresh variable, /b/
+   - This application gives the constraint  /b ~ int \rightarrow  c/.

--- a/Poly/hole-implementation.org
+++ b/Poly/hole-implementation.org
@@ -1,7 +1,12 @@
 * First try
-The naive implementation of just instantiating a fresh name for each hole doesn't work.
+ - The naive implementation of just instantiating a fresh name for each hole doesn't work.
    - Because, look at the term /let f = ? in f 1/. The hole should have a type of /int -> c/ for all /c/.
    - The inference rule for /let/ will generalise the type it's inferred for /f/, namely /a/ (a fresh variable for the hole)
    - The generalisation of /a/ is /∀ a . a/.
    - Then, when the type of /f/ is inferred in the application /f 1/, it's instantiated, giving a new fresh variable, /b/
    - This application gives the constraint  /b ~ int \rightarrow  c/.
+ - Clearly, there's nothing that can be written in /infer (Hole n) = .../ to make this work
+   - Instead, all the holes must be discovered before type-checking, and then can be added as a monomorphic
+	 type to the environment
+
+	

--- a/Poly/hole-implementation.org
+++ b/Poly/hole-implementation.org
@@ -1,12 +1,13 @@
-* First try
- - The naive implementation of just instantiating a fresh name for each hole doesn't work.
-   - Because, look at the term /let f = ? in f 1/. The hole should have a type of /int -> c/ for all /c/.
-   - The inference rule for /let/ will generalise the type it's inferred for /f/, namely /a/ (a fresh variable for the hole)
-   - The generalisation of /a/ is /∀ a . a/.
-   - Then, when the type of /f/ is inferred in the application /f 1/, it's instantiated, giving a new fresh variable, /b/
-   - This application gives the constraint  /b ~ int \rightarrow  c/.
- - Clearly, there's nothing that can be written in /infer (Hole n) = .../ to make this work
-   - Instead, all the holes must be discovered before type-checking, and then can be added as a monomorphic
-	 type to the environment
-
-	
+- The naive implementation of just instantiating a fresh name for each hole doesn't work.
+  - Because, look at the term /let f = ? in f 1/. The hole should have a type of /int -> c/ for all /c/.
+  - The inference rule for /let/ will generalise the type it's inferred for /f/, namely /a/ (a fresh variable for the hole)
+  - The generalisation of /a/ is /∀ a . a/.
+  - Then, when the type of /f/ is inferred in the application /f 1/, it's instantiated, giving a new fresh variable, /b/
+  - This application gives the constraint  /b ~ int \rightarrow  c/.
+- Clearly, there's nothing that can be written in /infer (Hole n) = .../ to make this work
+  - Instead, all the holes must be discovered before type-checking, and then can be added as a monomorphic
+	type to the environment
+  - Holes are similar to abstractions, in that:
+	     /a b ? c/     is similar to     /\hole -> a b hole c/
+  - That's why this approach works, but the previous approach doesn't because it's more like /let/ (where types are generalised where possible.)
+  - Now /infer (Hole n)/ is very similar to /infer (Var x)/.

--- a/Poly/src/Compiler.hs
+++ b/Poly/src/Compiler.hs
@@ -35,11 +35,11 @@ bracket :: String -> String
 bracket s = "(" ++ s ++ ")"
 
 data CompilerError = UndefinedVariable Ident
-                   | FoundHole
+                   | FoundHole Int
 
 instance Show CompilerError where
   show (UndefinedVariable v) = "undeclared variable: " ++ v
-  show FoundHole = "attempted to compile an incomplete expression containing a hole"
+  show (FoundHole n) = "attempted to compile an incomplete expression containing a hole"
 
 type Compiler = ReaderT [Ident] (Except CompilerError)
 
@@ -82,7 +82,7 @@ fromExpr (If cond t f) = do
 
 fromExpr (LitInt n) = return $ CLitInt n
 fromExpr (LitBool b) = return $ CLitBool b
-fromExpr Hole = throwError FoundHole
+fromExpr (Hole n) = throwError $ FoundHole n
 
 with :: Ident -> Compiler a -> Compiler a
 with i = local (i:)

--- a/Poly/src/Compiler.hs
+++ b/Poly/src/Compiler.hs
@@ -24,7 +24,7 @@ data Term = CVar Index
 instance Show Term where
   show (CVar i) = show i
   show (CAbs t) = "λ." ++ show t
-  show (CApp f x) =  bracket (show f) ++ bracket (show x)
+  show (CApp f x) = bracket (show f) ++ bracket (show x)
   show (CFix t) = "fix " ++ show t
   show (CIf cond t f) = "if " ++ show cond ++ " then " ++ show t ++ " else " ++ show f
   show (CLitInt i) = "#" ++ show i

--- a/Poly/src/Compiler.hs
+++ b/Poly/src/Compiler.hs
@@ -35,9 +35,11 @@ bracket :: String -> String
 bracket s = "(" ++ s ++ ")"
 
 data CompilerError = UndefinedVariable Ident
+                   | FoundHole
 
 instance Show CompilerError where
   show (UndefinedVariable v) = "undeclared variable: " ++ v
+  show FoundHole = "attempted to compile an incomplete expression containing a hole"
 
 type Compiler = ReaderT [Ident] (Except CompilerError)
 
@@ -80,6 +82,7 @@ fromExpr (If cond t f) = do
 
 fromExpr (LitInt n) = return $ CLitInt n
 fromExpr (LitBool b) = return $ CLitBool b
+fromExpr Hole = throwError FoundHole
 
 with :: Ident -> Compiler a -> Compiler a
 with i = local (i:)

--- a/Poly/src/Parser.hs
+++ b/Poly/src/Parser.hs
@@ -32,14 +32,6 @@ data Expr = Var Ident
           | Hole Int
           deriving (Eq, Ord)
 
-traverseExpr :: Monad m => (Expr -> m a) -> Expr -> m a
-traverseExpr l (App f x) = traverseExpr l f >> traverseExpr l x
-traverseExpr l (Abs v t) = traverseExpr l t
-traverseExpr l (Let v val body) = traverseExpr l val >> traverseExpr l body
-traverseExpr l (LetRec v val body) = traverseExpr l val >> traverseExpr l body
-traverseExpr l (If cond t f) = traverseExpr l cond >> traverseExpr l t >> traverseExpr l f
-traverseExpr l t = l t
-
 parseProgram = parseWrapper program
 parseExpr = parseWrapper (numberHoles <$> expr)
 
@@ -196,3 +188,11 @@ numberHoles e = evalState (num e) 0
           n <- S.get
           modify (+1)
           return $ Hole n
+          
+traverseExpr :: Monad m => (Expr -> m a) -> Expr -> m a
+traverseExpr l (App f x) = traverseExpr l f >> traverseExpr l x
+traverseExpr l (Abs v t) = traverseExpr l t
+traverseExpr l (Let v val body) = traverseExpr l val >> traverseExpr l body
+traverseExpr l (LetRec v val body) = traverseExpr l val >> traverseExpr l body
+traverseExpr l (If cond t f) = traverseExpr l cond >> traverseExpr l t >> traverseExpr l f
+traverseExpr l t = l t

--- a/Poly/src/Parser.hs
+++ b/Poly/src/Parser.hs
@@ -153,6 +153,7 @@ instance Show Expr where
   show (If cond t f) = "if " ++ show cond ++ " then " ++ show t ++ " else " ++ show f
   show (LitInt i) = show i
   show (LitBool b) = show b
+  show Hole = "?"
 
 unfoldAbs :: Expr -> ([Ident], Expr)
 unfoldAbs (Abs v t) = (v:vs, t')
@@ -163,4 +164,5 @@ brack :: Expr -> String
 brack (Var v) = v
 brack (LitInt i) = show i
 brack (LitBool b) = show b
+brack Hole = show Hole
 brack e = "(" ++ show e ++ ")"

--- a/Poly/src/Parser.hs
+++ b/Poly/src/Parser.hs
@@ -25,6 +25,7 @@ data Expr = Var Ident
           | If Expr Expr Expr
           | LitInt Int
           | LitBool Bool
+          | Hole
           deriving (Eq, Ord)
 
 parseProgram = parseWrapper program
@@ -54,13 +55,16 @@ expr = choice [ app
               , ifExpr ]
 
 atom :: ReadP Expr
-atom = choice [var, bracket, litInt, litBool]
+atom = choice [var, hole, bracket, litInt, litBool]
 
 app :: ReadP Expr
 app = chainl1 atom (space >> return App)
 
 var :: ReadP Expr
 var = Var <$> ident
+
+hole :: ReadP Expr
+hole = string "?" >> return Hole
 
 abstr :: ReadP Expr
 abstr = do

--- a/Poly/src/Types.hs
+++ b/Poly/src/Types.hs
@@ -156,6 +156,7 @@ infer (If cond t f) = do
 
 infer (LitInt _) = return tyInt
 infer (LitBool _) = return tyBool
+infer (Hole n) = fresh
 
 runInfer :: Env -> Infer a -> Except TypeError (a, [Constraint])
 runInfer env i = evalRWST i env allVars
@@ -244,4 +245,3 @@ rename t = S.evalState (rename' t) (allVars, [])
             Nothing -> do S.put (rest, (v, new) : existing)
                           return $ TyVar new
         rename' (TyConstr c ts) = TyConstr c <$> traverse rename' ts
-

--- a/Poly/src/Types.hs
+++ b/Poly/src/Types.hs
@@ -12,6 +12,7 @@ module Types ( GenericType (..)
              , (-->) ) where
 
 import qualified Control.Monad.State.Lazy as S
+import qualified Control.Monad.Writer as W
 
 import Data.List
 import Data.Maybe
@@ -86,24 +87,41 @@ sub :: Subst -> Type -> Type
 sub s t@(TyVar v) = fromMaybe t (lookup v s)
 sub s (TyConstr c ts) = TyConstr c (map (sub s) ts)
 
+subScheme :: Subst -> Scheme -> Scheme
+subScheme s (Forall vs t) = Forall vs (sub s t)
+
+subEnv :: Subst -> Env -> Env
+subEnv s e = [ (id, subScheme s sch) | (id, sch) <- e ]
+
 type Constraint = (Type, Type)
 
 data TypeError = UnifyInfiniteError Ident Type
                | UnifyConstructorsError Ident Ident
                | UnifyConstructorArityMismatch Ident Int Int
                | UnboundVariableError Ident
+               | HasHoles Type [BoundHole]
 
 instance Show TypeError where
   show (UnifyInfiniteError v t) = "could not construct infinite type " ++ v ++ " ~ " ++ show t
   show (UnifyConstructorsError c1 c2) = "could not unify different constructors " ++ c1 ++ " and " ++ c2
   show (UnifyConstructorArityMismatch c a1 a2) = "constructor arity mismatch for " ++ c ++ ": " ++ show a1 ++ " vs " ++ show a2
   show (UnboundVariableError v) = "unbound variable: " ++ v
+  show (HasHoles ty hs) = "found holes in term of type : " ++ show ty ++ "\n" ++ intercalate "\n" (map show hs)
+
+data BoundHole = BoundHole Type Env
+
+instance Show BoundHole where
+  show (BoundHole ty env)
+    | null env' = "    hole : " ++ show ty ++ "\n      no relevant bindings"
+    | otherwise = "    hole : " ++ show ty ++ "\n      relevant bindings include:\n"
+                            ++ intercalate "\n" [ "        " ++ id ++ " : " ++ show t | (id, t) <- env' ]
+    where env' = takeWhile (\(id, _) -> head id /= '?') env
 
 type Infer = RWST
-  Env                -- typing environment
-  [Constraint]       -- constraints accumulator
-  [Ident]            -- fresh variable names
-  (Except TypeError) -- errors
+  Env                         -- typing environment
+  ([Constraint], [BoundHole]) -- constraints accumulator
+  [Ident]                     -- fresh variable names
+  (Except TypeError)          -- errors
 
 infer :: Expr -> Infer Type
 
@@ -112,6 +130,15 @@ infer (Var x) = do
   case lookup x env of
     Nothing -> throwError $ UnboundVariableError x
     Just t -> instantiate t
+
+infer (Hole n) = do
+  env <- ask
+  case lookup ("?" ++ show n) env of
+    Nothing -> error "hole variable not defined in the env - this shouldn't happen"
+    Just t -> do
+      ty <- instantiate t
+      tell ([], [BoundHole ty env])
+      return ty
 
 infer (Abs x e) = do
   tv <- fresh
@@ -129,7 +156,7 @@ infer (App f x) = do
   return tv
 
 infer (Let x e b) = do
-  (te, cs) <- listen $ infer e
+  (te, (cs, _)) <- listen $ infer e
   s <- lift $ runUnify (solve cs)
   sch <- generalise (sub s te) -- fixed bug: let two = (\n -> add n 1) 1 in two
   with (x, sch) (infer b)
@@ -154,9 +181,8 @@ infer (If cond t f) = do
 
 infer (LitInt _) = return tyInt
 infer (LitBool _) = return tyBool
-infer (Hole n) = fresh
 
-runInfer :: Env -> Infer a -> Except TypeError (a, [Constraint])
+runInfer :: Env -> Infer a -> Except TypeError (a, ([Constraint], [BoundHole]))
 runInfer env i = evalRWST i env allVars
 
 instantiate :: Scheme -> Infer Type
@@ -180,7 +206,7 @@ fresh :: Infer Type
 fresh = fmap TyVar freshName
 
 (~~) :: Type -> Type -> Infer ()
-(~~) a b = tell [(a, b)]
+(~~) a b = tell ([(a, b)], [])
 
 with :: (Ident, Scheme) -> Infer a -> Infer a
 with p = local (p :)
@@ -222,11 +248,27 @@ v `extend` t | t == TyVar v = return ()
 compose :: Subst -> Subst -> Subst
 compose s1 s2 = map (fmap (sub s1)) s2 ++ s1
 
+holesIn :: Expr -> [Int]
+holesIn e = snd (W.runWriter (traverseExpr he e))
+  where he :: Expr -> W.Writer [Int] ()
+        he (Hole n) = tell [n]
+        he t = return ()
+
+holeEnv :: [Int] -> Env
+holeEnv holes = [ (h, Forall [] $ TyVar h) | hole <- holes, let h = show (Hole hole) ]
+
 typecheck :: Env -> Expr -> Except TypeError Scheme
 typecheck e t = do
-  (t, cs) <- runInfer e (infer t)
+  let holes = holesIn t
+  
+  (t, (cs, hs)) <- runInfer (holeEnv holes ++ e) (infer t)
   s <- runUnify (solve cs)
-  return $ finalise (sub s t)
+  case hs of
+    [] -> return $ finalise (sub s t)
+    holes -> do
+      let r = makeRenamer t `compose` s
+      throwError $ HasHoles (sub r t) [ BoundHole (sub r th) (subEnv r env)
+                                      | (BoundHole th env) <- holes ]
 
 finalise :: Type -> Scheme
 finalise t = let t' = rename t
@@ -236,12 +278,11 @@ rename :: Type -> Type
 rename t = sub (makeRenamer t) t
 
 makeRenamer :: Type -> Subst
-makeRenamer t = snd $ S.execState (mk t) (allVars, [])
-  where mk :: Type -> S.State ([Ident], Subst) ()
-        mk (TyVar v) = do
+makeRenamer t = snd $ S.execState (traverse mk t) (allVars, [])
+  where mk :: Ident -> S.State ([Ident], Subst) ()
+        mk v = do
           state <- S.get
           let ((new:rest), existing) = state
           case lookup v existing of
             Just n -> return ()
             Nothing -> S.put (rest, (v, TyVar new) : existing)
-        mk (TyConstr c ts) = void $ traverse mk ts


### PR DESCRIPTION
I've implemented a system to infer the type of holes ("?") in expressions.

For example, `let f = ? in f 1` is now valid syntax, and the type of the hole is derived as `int -> a`.